### PR TITLE
Add arm64 version of tmodloader image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ich777/debian-baseimage
+FROM ich777/debian-baseimage:latest_arm64
 
 LABEL maintainer="admin@minenet.at"
 
@@ -9,7 +9,14 @@ RUN export TZ=Europe/Rome && \
 	apt-get -y install --no-install-recommends screen unzip curl && \
 	rm -rf /var/lib/apt/lists/*
 
-RUN wget -O /tmp/gotty.tar.gz https://github.com/yudai/gotty/releases/download/v1.0.1/gotty_linux_amd64.tar.gz && \
+RUN apt update && \
+    apt install -y apt-transport-https dirmngr gnupg ca-certificates && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
+	echo "deb https://download.mono-project.com/repo/debian stable-buster main" | tee /etc/apt/sources.list.d/mono-official-stable.list && \
+	apt update && \
+	apt install -y mono-devel
+
+RUN wget -O /tmp/gotty.tar.gz https://github.com/yudai/gotty/releases/download/v1.0.1/gotty_linux_arm.tar.gz && \
 	tar -C /usr/bin/ -xvf /tmp/gotty.tar.gz && \
 	rm -rf /tmp/gotty.tar.gz
 
@@ -18,7 +25,7 @@ ENV SERVER_DIR="${DATA_DIR}/serverfiles"
 ENV GAME_VERSION="template"
 ENV GAME_MOD="template"
 ENV GAME_PARAMS="template"
- ENV TARRARIA_SRV_V="1.4.2.3" 
+ENV TARRARIA_SRV_V="1.4.2.3"
 ENV ENABLE_WEBCONSOLE="true"
 ENV GOTTY_PARAMS="-w --title-format Terraria-tModloader"
 ENV UMASK=000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ich777/debian-baseimage:latest_arm64
+FROM ich777/mono-baseimage:latest_arm64
 
 LABEL maintainer="admin@minenet.at"
 
@@ -8,13 +8,6 @@ RUN export TZ=Europe/Rome && \
 	echo $TZ > /etc/timezone && \
 	apt-get -y install --no-install-recommends screen unzip curl && \
 	rm -rf /var/lib/apt/lists/*
-
-RUN apt update && \
-    apt install -y apt-transport-https dirmngr gnupg ca-certificates && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
-	echo "deb https://download.mono-project.com/repo/debian stable-buster main" | tee /etc/apt/sources.list.d/mono-official-stable.list && \
-	apt update && \
-	apt install -y mono-devel
 
 RUN wget -O /tmp/gotty.tar.gz https://github.com/yudai/gotty/releases/download/v1.0.1/gotty_linux_arm.tar.gz && \
 	tar -C /usr/bin/ -xvf /tmp/gotty.tar.gz && \

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -98,6 +98,14 @@ if [ ! -f "${SERVER_DIR}/serverconfig.txt" ]; then
   cd ${SERVER_DIR}
   wget -qi serverconfig.txt "https://raw.githubusercontent.com/ich777/docker-terraria-server/master/config/serverconfig.txt"
 fi
+
+# Hack to force usage of system mono
+cd "${SERVER_DIR}"
+rm System*
+rm Mono*
+rm monoconfig
+rm mscorlib.dll
+
 echo "---Server ready---"
 chmod -R ${DATA_PERM} ${DATA_DIR}
 echo "---Checking for old logs---"
@@ -106,7 +114,7 @@ screen -wipe 2&>/dev/null
 
 echo "---Start Server---"
 cd ${SERVER_DIR}
-screen -S Terraria -L -Logfile ${SERVER_DIR}/masterLog.0 -d -m ${SERVER_DIR}/tModLoaderServer -tmlsavedirectory ${SERVER_DIR}/TML ${GAME_PARAMS}
+screen -S Terraria -L -Logfile ${SERVER_DIR}/masterLog.0 -d -m mono ${SERVER_DIR}/tModLoaderServer.exe -tmlsavedirectory ${SERVER_DIR}/TML ${GAME_PARAMS}
 sleep 2
 if [ "${ENABLE_WEBCONSOLE}" == "true" ]; then
     /opt/scripts/start-gotty.sh 2>/dev/null &

--- a/scripts/start-watchdog.sh
+++ b/scripts/start-watchdog.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-killpid="$(pidof tModLoaderServer.bin.x86_64)"
+killpid="$(pidof mono)"
 while true
 do
 	tail --pid=$killpid -f /dev/null


### PR DESCRIPTION
Let me know if you end up making an arm version of your mono base image, and I can update this to use the mono image instead of manually installing mono.

My changes boil down to:

- Need to use arm version of gotty
- Install and use system mono (6.12) to run tModLoaderServer.exe (5.18
  doesn't work)
- Need to wait on mono process rather than tModLoader in watchdog script